### PR TITLE
Sort may occur `string comparison failed` when item has special character

### DIFF
--- a/1pass
+++ b/1pass
@@ -155,7 +155,7 @@ list_items()
     if [ ! -r $index ] || [ $refresh -eq 1 ]; then
         fetch_index
     fi
-    gpg -qd $index | jq -r ".[].overview.title" | sort -bf
+    gpg -qd $index | jq -r ".[].overview.title" | LC_ALL="C" bash -c 'sort -bf'
 }
 
 #


### PR DESCRIPTION
eg:
```bash
» echo "你好\nabc" | sort -bf                                                                                                                                                                                        
sort: string comparison failed: Illegal byte sequence
sort: Set LC_ALL='C' to work around the problem.
sort: The strings compared were `Ľ\240ť\275' and `ABC'.
```