### PR TITLE
Fix to allow for item names with spaces

### DIFF
--- a/1pass
+++ b/1pass
@@ -316,7 +316,7 @@ shift $((OPTIND-1))
 if [ $# -eq 0 ]; then
     list_items
 elif [ $# -eq 1 ]; then
-    get_by_title $1 password
+    get_by_title "$1" password
 elif [ $# -eq 2 ]; then
-    get_by_title $1 $2
+    get_by_title "$1" $2
 fi


### PR DESCRIPTION
I have a bunch of 1Password items with spaces in the titles that weren't working with 1pass. Needed to wrap the function parameters in quotes in order to preserve the spaces.