### PR TITLE
Add support for other 1password regions

### DIFF
--- a/1pass
+++ b/1pass
@@ -53,8 +53,8 @@ self_key=
 # set to the email address associated with your 1Password account
 email=
 
-# set to your subdomain of 1password.com
-subdomain=
+# set to your 1password domain
+domain=
 CONFIG
     chmod go-rw ${op_dir}/config
     echo "please config 1pass by editing ${op_dir}/config"
@@ -81,10 +81,11 @@ if [ "$self_key" == "" ]; then
     exit 1
 fi
 
-if [ "$subdomain" == "" ]; then
-    echo "please configure your 1Password subdomain in ${op_dir}/config"
+if [ "$subdomain" == "" ] && [ "$domain" == "" ]; then
+    echo "please configure your 1Password domain in ${op_dir}/config"
     exit 1
 fi
+domain=${domain:-${subdomain}.1password.com}
 
 if [ ! -r ${master} ]; then
     echo "please put your master password into ${master}"
@@ -93,11 +94,10 @@ if [ ! -r ${master} ]; then
 fi
 
 if [ ! -r ${secret} ]; then
-    echo "please put your ${subdomain}.1password.com secret key into ${secret}"
+    echo "please put your ${domain} secret key into ${secret}"
     echo "ex: echo \"A3-XXXXXX-XXXXXX-XXXXX-XXXXX-XXXXX-XXXXX\" | gpg -er $email > ${secret}"
     exit 1
 fi
-
 
 index=${cache_dir}/_index.gpg
 session=${cache_dir}/_session.gpg
@@ -108,7 +108,7 @@ refresh=0
 verbose=0
 print_output=0
 clip_time=30
-OP_SESSION_NAME=${subdomain//-/_}
+OP_SESSION_NAME=$(echo "$domain" | cut -f1 -d'.' | tr '-' '_')
 
 usage()
 {
@@ -137,11 +137,11 @@ signin()
     local pw=$(gpg -d -q $master)
     local se=$(gpg -d -q $secret)
     if [ $verbose -eq 1 ]; then
-        echo "signing in to ${subdomain}.1password.com $email"
+        echo "signing in to ${domain} $email"
     fi
-    local token=$(echo -n "${pw}" | op signin --output=raw ${subdomain}.1password.com $email $se || echo -n "_fail_")
+    local token=$(echo -n "${pw}" | op signin --output=raw ${domain} $email $se || echo -n "_fail_")
     if [ "$token" == "_fail_" ]; then
-        echo "1pass failed to signin to ${subdomain}.1password.com"
+        echo "1pass failed to signin to ${domain}"
         exit 1
     fi
     echo -n "${token}" | gpg -qe --batch -r $self_key > $session

--- a/1pass
+++ b/1pass
@@ -53,7 +53,7 @@ self_key=
 # set to the email address associated with your 1Password account
 email=
 
-# set to your 1password domain
+# set to your 1password domain (e.g. example.1password.com)
 domain=
 CONFIG
     chmod go-rw ${op_dir}/config
@@ -82,7 +82,7 @@ if [ "$self_key" == "" ]; then
 fi
 
 if [ "$subdomain" == "" ] && [ "$domain" == "" ]; then
-    echo "please configure your 1Password domain in ${op_dir}/config"
+    echo "please configure your 1Password domain in ${op_dir}/config, e.g. example.1password.com"
     exit 1
 fi
 domain=${domain:-${subdomain}.1password.com}

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ In order to run with minimum user input, **1pass** relies on the Gnu Privacy Gua
 password* and a *secret key* to access your vault. Each of these must be stored in an encrypted file
 (in ~/.1pass or `$XDG_CONFIG_HOME/1pass`) for 1pass to work correctly. 1pass encrypts these and all other files
 with your own gpg key. This key, as well as your 1Password login email and domain must be
-configured in the ~/.1pass/config file.
+configured in the ~/.1pass/config file. The domain is the full domain name that
+you use to sign-in when you use the 1Password website, for example
+`example.1password.com` or `subdomain.1password.ca`.
 
 GPG can be configured to use the ```gpg-agent```, which can prompt for your *gpg* password, and
 cache it in a local agent for a fixed amount of time. If you configure GPG this way, you will only

--- a/config.sample
+++ b/config.sample
@@ -6,5 +6,5 @@ self_key=<key-id>
 # set to the email address associated with your 1Password account
 email=<email address>
 
-# set to your subdomain of 1password.com
-subdomain=<subdomain>
+# set to your 1password domain
+domain=<domain>

--- a/config.sample
+++ b/config.sample
@@ -6,5 +6,5 @@ self_key=<key-id>
 # set to the email address associated with your 1Password account
 email=<email address>
 
-# set to your 1password domain
-domain=<domain>
+# set to your 1password domain (e.g. example.1password.com)
+domain=<example.1password.com>


### PR DESCRIPTION
1password supports multiple regions, available through multiple domains, like my.1password.ca and my.1password.eu. Accounts from one region cannot sign in to another region. The full domain needs to be provided to `op` to successfully sign in.

The `subdomain` option is still supported, and defaults to 1password.com so as to not break existing setups.