### PR TITLE
Conform to XDG Base Dir spec

### DIFF
--- a/1pass
+++ b/1pass
@@ -23,9 +23,17 @@ set -o pipefail
 
 VERSION="1.0.1"
 
-op_bin=$HOME/bin/op
-op_dir=${HOME}/.1pass
-cache_dir=${op_dir}/cache
+if [ "$XDG_CONFIG_HOME" != "" ] && [ ! -d "${HOME}/.1pass" ]; then
+    op_dir="${XDG_CONFIG_HOME}/1pass"
+else
+    op_dir=${HOME}/.1pass
+fi
+
+if [ "$XDG_CACHE_HOME" != "" ] && [ ! -d "${op_dir}/cache" ]; then
+    cache_dir="${XDG_CACHE_HOME}/1pass"
+else
+    cache_dir=${op_dir}/cache
+fi
 
 # check for bare -V/version request first:
 if [ $# -eq 1 ] && [ "$1" == "-V" ]; then

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ any running gpg-agent of your GPG secret keys.
 In order to run with minimum user input, **1pass** relies on the Gnu Privacy Guard
 [gpg](https://gnupg.org/) to encrypt all locally stored data. 1Password needs both a *master
 password* and a *secret key* to access your vault. Each of these must be stored in an encrypted file
-(in the ~/.1pass) directory for 1pass to work correctly. 1pass encrypts these and all other files
-with your own gpg key. This key, as well as your 1Password login email and subdomain must be
+(in ~/.1pass or `$XDG_CONFIG_HOME/1pass`) for 1pass to work correctly. 1pass encrypts these and all other files
+with your own gpg key. This key, as well as your 1Password login email and domain must be
 configured in the ~/.1pass/config file.
 
 GPG can be configured to use the ```gpg-agent```, which can prompt for your *gpg* password, and


### PR DESCRIPTION
Use`XDG_CONFIG_HOME` and `XDG_CACHE_HOME` if set, and `~/.1pass` does not exist.
    
The [XDG Base Directory Spec](https://standards.freedesktop.org/basedir-spec/latest/) helps keep home directories clean of dotfiles, and helps separate the cache and config directories for potential versioning.