### PR TITLE
Add ability to list fields from the selected item

### DIFF
--- a/1pass
+++ b/1pass
@@ -117,6 +117,7 @@ verbose=0
 print_output=0
 clip_time=30
 OP_SESSION_NAME=$(echo "$domain" | cut -f1 -d'.' | tr '-' '_')
+list_fields=0
 
 usage()
 {
@@ -126,6 +127,7 @@ usage: 1pass [-fhprv] [<Item> [<username|password|totp>]]
   -f   Forget GPG key from gpg-agent, and remove local session
   -h   Help
   -p   Print the 1pass output to stdout, rather than copying to the clipboard
+  -l   List all the known fields for the specified item
   -r   Refresh all appropriate data from 1password.com, ignoring local cache
   -v   Verbose output
   -V   Print 1pass version and exit
@@ -317,6 +319,37 @@ get_005()
 }
 
 #
+# fetch the list of fields from template 001 ("Login")
+#
+get_fields_001()
+{
+    _get_fields_template "$1" "username" "password"
+}
+
+#
+# fetch the list of fields from template 005 ("Password")
+#
+get_fields_005()
+{
+    _get_fields_template "$1" "password"
+}
+
+_get_fields_template()
+{
+    local uuid=$1
+    shift
+    local q='.details.sections[] | select(.fields).fields[] | select(.t!="").t'
+    local fields=("${@}")
+    ensure_item "$uuid"
+    while read -r f; do 
+        fields+=("$f")
+    done < <(gpg -qd "${cache_dir}/${uuid}.gpg" | jq -r "${q}" || echo -n "_fail_")
+    get_result=$(_join_by $'\n' "${fields[@]}")
+}
+
+function _join_by { local IFS="$1"; shift; echo "$*"; }
+
+#
 # fetch a TOTP value for the given item
 #
 get_totp()
@@ -370,8 +403,19 @@ output_result()
 
 get_by_title()
 {
-    local title=$1
-    local field=$2
+    _get_by "get_" "${@}"
+}
+
+get_fields_by_title()
+{
+    _get_by "get_fields_" "${@}"
+}
+
+_get_by()
+{
+    local func=$1
+    local title=$2
+    local field=$3
     if [ ! -r "$index" ] || [ $refresh -eq 1 ]; then
         fetch_index
     fi
@@ -379,14 +423,14 @@ get_by_title()
     q=".[] | select(.overview.title==\"${title}\").uuid + \":\" + select(.overview.title==\"${title}\").templateUuid"
     IFS=':' read -r uuid tid <<< "$(gpg -qd "$index" | jq -r "${q}")"
     if [ "$tid" != "" ]; then
-        "get_${tid}" "$uuid" "$field"
+        "${func}${tid}" "$uuid" "$field"
         if [ $? ]; then
             output_result
         fi
     fi
 }
 
-while getopts "f?h?p?r?v?:" opt; do
+while getopts "f?h?p?l?r?v?:" opt; do
     case $opt in
         h)
             usage
@@ -398,6 +442,10 @@ while getopts "f?h?p?r?v?:" opt; do
             ;;
         p)
             print_output=1
+            ;;
+        l)
+            print_output=1
+            list_fields=1
             ;;
         r)
             refresh=1
@@ -418,7 +466,11 @@ sanity_check
 if [ $# -eq 0 ]; then
     list_items
 elif [ $# -eq 1 ]; then
-    get_by_title "$1" password
+    if [[ $list_fields -eq 1 ]]; then
+        get_fields_by_title "$1"
+    else
+        get_by_title "$1" password
+    fi
 elif [ $# -eq 2 ]; then
     case "$2" in
         totp ) get_totp "$1"          ;;

--- a/README.md
+++ b/README.md
@@ -58,6 +58,27 @@ curl https://raw.githubusercontent.com/dcreemer/1pass/master/1pass > /usr/local/
 chmod a+x /usr/local/bin/1pass
 ```
 
+### Bash Completion
+
+If you would like to install bash-completion for 1pass, place the `bash-completion.sh` script in
+and accessible location and then source it from your `.bash_profile`.  For example:
+
+```sh
+mkdir -p /usr/local/etc/1pass
+curl https://raw.githubusercontent.com/dcreemer/1pass/master/bash_completion.sh > /usr/local/etc/1pass/bash_completion.sh
+echo "source /usr/local/etc/1pass/bash_completion.sh" >> ~/.bash_profile
+```
+
+By default the completion script will look for fzf on your path.  If present, it will use fzf completion
+([see here](https://github.com/junegunn/fzf#fuzzy-completion-for-bash-and-zsh)). If you do not have fzf or if you turn 
+this feature off it will revert to standard bash completion behavior.  If you would like to explicitly disable
+FZF completion for 1pass, you can do so as follows:
+
+```sh
+export ONEPASS_FZF_COMPLETE=false
+```
+This line should be added to your `.bash_profile`
+
 ## Security and Warning
 
 **1pass** requires you to store your 1Password master password in a local GPG-encrypted file. You

--- a/README.md
+++ b/README.md
@@ -69,10 +69,14 @@ curl https://raw.githubusercontent.com/dcreemer/1pass/master/bash_completion.sh 
 echo "source /usr/local/etc/1pass/bash_completion.sh" >> ~/.bash_profile
 ```
 
-By default the completion script will look for fzf on your path.  If present, it will use fzf completion
-([see here](https://github.com/junegunn/fzf#fuzzy-completion-for-bash-and-zsh)). If you do not have fzf or if you turn 
-this feature off it will revert to standard bash completion behavior.  If you would like to explicitly disable
-FZF completion for 1pass, you can do so as follows:
+By default the completion script will look for `fzf` completion support in your environment. If present, 
+it will use fzf completion ([see here](https://github.com/junegunn/fzf#fuzzy-completion-for-bash-and-zsh)). 
+
+_Note: If you have installed `fzf` using homebrew on macOS, make sure you have enabled completion by
+running `$(brew --prefix)/opt/fzf/install --completion` and follow the prompts._
+
+If you do not have fzf or if you turn this feature off it will revert to standard bash completion 
+behavior. If you would like to explicitly disable FZF completion for 1pass, you can do so as follows:
 
 ```sh
 export ONEPASS_FZF_COMPLETE=false

--- a/bash_completion.sh
+++ b/bash_completion.sh
@@ -1,0 +1,75 @@
+function _fzf_complete_1pass() {
+  local doFzf=false
+  local cword="${COMP_WORDS[$COMP_CWORD]}"
+  if _should_1p_fzf_complete; then
+    doFzf=true
+    local trigger=${FZF_COMPLETION_TRIGGER-'**'}
+    if [[ -z "$cword" ]]; then
+      COMP_WORDS[$COMP_CWORD]=$trigger
+    elif [[ "$cword" != *"$trigger" ]]; then
+      COMP_WORDS[$COMP_CWORD]="$cword$trigger"
+    fi
+  fi
+
+  local item
+  local words=("${COMP_WORDS[@]::${#COMP_WORDS[@]}-1}")
+  for i in "${!words[@]}"; do
+    local curr=${words[$i]}
+    if [[ $i -ne 0 ]] && [[ ${curr} != "-"* ]]; then
+      item=${curr}
+      break
+    fi
+  done
+  # Avoid any aliases that might be set
+  local opcmd="command 1pass"
+  local rcmd=""
+  if [[ -z "$item" ]]; then
+    rcmd="${opcmd}"
+  else
+    rcmd="${opcmd} -l \"$item\""
+  fi
+  if ${doFzf}; then
+      _fzf_complete --reverse --prompt="1pass> " -- "${@}" < <(eval "$rcmd")
+  else
+    COMPREPLY=()
+    local search
+    # The rest adapted from https://stackoverflow.com/a/1146716/190100
+    search=$(eval echo "$cword" 2>/dev/null || eval echo "$cword'" 2>/dev/null || eval echo "$cword\"" 2>/dev/null || "" )
+    local IFS=$'\n'
+    while read -r line; do COMPREPLY+=("$line"); done < <(compgen -W "$(_1p_entries "${rcmd}")" -- "$search")
+    local escaped_single_qoute="'\''"
+    local i=0
+    for entry in ${COMPREPLY[*]}
+    do
+        if [[ "${cword:0:1}" == "'" ]] 
+        then
+            # started with single quote, escaping only other single quotes
+            # [']bla'bla"bla\bla bla --> [']bla'\''bla"bla\bla bla
+            COMPREPLY[$i]="${entry//\'/${escaped_single_qoute}}" 
+        elif [[ "${cword:0:1}" == "\"" ]] 
+        then
+            # started with double quote, escaping all double quotes and all backslashes
+            # ["]bla'bla"bla\bla bla --> ["]bla'bla\"bla\\bla bla
+            entry="${entry//\\/\\\\}" 
+            COMPREPLY[$i]="${entry//\"/\\\"}" 
+        else 
+            # no quotes in front, escaping _everything_
+            # [ ]bla'bla"bla\bla bla --> [ ]bla\'bla\"bla\\bla\ bla
+            entry="${entry//\\/\\\\}" 
+            entry="${entry//\'/\'}" 
+            entry="${entry//\"/\\\"}" 
+            COMPREPLY[$i]="${entry// /\\ }"
+        fi
+        (( i++ ))
+    done
+  fi
+}
+complete -F _fzf_complete_1pass -o default -o bashdefault 1pass
+
+function _should_1p_fzf_complete() {
+  ${ONEPASS_FZF_COMPLETE:-true} && declare -f _fzf_complete > /dev/null 2>&1
+}
+
+function _1p_entries() {
+  eval "${@}" | sed -e "{" -e 's#\\#\\\\#g' -e "s#'#\\\'#g" -e 's#"#\\\"#g' -e "}"
+}


### PR DESCRIPTION
Adds a `-l` (lowercase "L") option to the command to list the available fields on an item.

I'm planning to use this capability to add to an fzf completion function to use with bash completion for 1pass.  If I get that all working I'll throw out a PR for a readme update with the details.