### PR TITLE
Make fuzzpass.sh POSIX compatible for broad shell support.

### DIFF
--- a/fuzzpass.sh
+++ b/fuzzpass.sh
@@ -13,7 +13,7 @@
 fuzzpass() {
     local arg
     arg=$1
-    if [ "$arg" == "" ]; then
+    if [ "$arg" = "" ]; then
         arg="password"
     fi
     local item


### PR DESCRIPTION
Specifically, this allows `zsh` users to call `fuzzpass`. See [this stackoverflow](https://stackoverflow.com/questions/20449543/shell-equality-operators-eq) thread for some more info.