### PR TITLE
Fix issue with totp password not being pipeable

### DIFF
--- a/1pass
+++ b/1pass
@@ -198,7 +198,6 @@ signin()
     se=$("$GPG" -d -q "$secret")
     if [ "${use_totp}" == "1" ]; then
         local ot
-        local totp
         totp=$("$GPG" -d -q "$totp")
         ot=$(oathtool -b --totp "$totp")
     fi
@@ -466,9 +465,17 @@ get_totp()
     if [ ! -r "$index" ] || [ $refresh -eq 1 ]; then
         fetch_index
     fi
-    local uuid
-    uuid=$("$GPG" -qd "$index" | jq -r ".[] | select(.overview.title==\"${1}\").uuid")
+    local title
+    title="${1}"
+    if [ "$title" == "-" ]; then
+        # read title from stdin. turn off error propogation to handle EOF as well as NL
+        set +e
+        read -r title
+        set -e
+    fi
 
+    local uuid
+    uuid=$("$GPG" -qd "$index" | jq -r ".[] | select(.overview.title==\"$title\").uuid")
     # Fetch the TOTP
     if [ $verbose -eq 1 ]; then
         echo "fetching TOTP for $uuid" 1>&2


### PR DESCRIPTION
This pull request fixes an issue with piping from stdout to 1pass.
Previously when piping to 1pass for a totp password, you would get an error saying `<item>` is empty.
This is due to `-` never being substituted for the item you are querying for.

With these changes it is now possible to call `echo "GitHub" | 1pass - totp` and get the one-time password from 1pass.
