### PR TITLE
Add API Credentials template support

### DIFF
--- a/1pass
+++ b/1pass
@@ -413,6 +413,20 @@ get_110()
 }
 
 #
+# fetch a field from template 112 ("API Credential")
+#
+get_112()
+{
+  local uuid=$1
+  local field=${2/"DEFAULT"/"credential"}
+  local q=".details.sections[] | select(.fields).fields[] | select(.t==\"${field}\").v"
+
+  ensure_item "$uuid"
+
+  get_result=$(gpg -qd "${cache_dir}/${uuid}.gpg" | jq -r "${q}" || echo -n "_fail_")
+}
+
+#
 # fetch the list of fields from template 001 ("Login")
 #
 get_fields_001()


### PR DESCRIPTION
While attempting to pull some API credentials from a vault, I was getting this error

```
/usr/local/bin/1pass: line 553: get_112: command not found
```

Added support for API credentials template and this works as expected.