### PR TITLE
Fully respect xdg base dir spec

### DIFF
--- a/1pass
+++ b/1pass
@@ -21,18 +21,22 @@
 set -e
 set -o pipefail
 
-VERSION="1.6.1"
+VERSION="1.6.2"
 
-if [ "$XDG_CONFIG_HOME" != "" ] && [ ! -d "${HOME}/.1pass" ]; then
-    op_dir="${XDG_CONFIG_HOME}/1pass"
+if [ "$OVERRIDE_1PASS_CONF_DIR" != "" ]; then
+  op_dir="${OVERRIDE_1PASS_CONF_DIR}"
+elif [ "$XDG_CONFIG_HOME" != "" ]; then
+  op_dir="${XDG_CONFIG_HOME}/1pass"
 else
-    op_dir=${HOME}/.1pass
+  op_dir="${HOME}/.config/1pass"
 fi
 
-if [ "$XDG_CACHE_HOME" != "" ] && [ ! -d "${op_dir}/cache" ]; then
-    cache_dir="${XDG_CACHE_HOME}/1pass"
+if [ "$OVERRIDE_1PASS_CACHE_DIR" != "" ]; then
+  cache_dir="${OVERRIDE_1PASS_CACHE_DIR}"
+elif [ "$XDG_CACHE_HOME" != "" ]; then
+  cache_dir="${XDG_CACHE_HOME}/1pass"
 else
-    cache_dir=${op_dir}/cache
+  cache_dir="${HOME}/.cache/1pass"
 fi
 
 os=$(uname)

--- a/1pass
+++ b/1pass
@@ -21,18 +21,18 @@
 set -e
 set -o pipefail
 
-VERSION="1.6.2"
+VERSION="1.6.1"
 
-if [ "$OVERRIDE_1PASS_CONF_DIR" != "" ]; then
-  op_dir="${OVERRIDE_1PASS_CONF_DIR}"
+if [ -d "${HOME}/.1pass" ]; then
+  op_dir="${HOME}/.1pass"
 elif [ "$XDG_CONFIG_HOME" != "" ]; then
   op_dir="${XDG_CONFIG_HOME}/1pass"
 else
   op_dir="${HOME}/.config/1pass"
 fi
 
-if [ "$OVERRIDE_1PASS_CACHE_DIR" != "" ]; then
-  cache_dir="${OVERRIDE_1PASS_CACHE_DIR}"
+if [ -d "${op_dir}/cache" ]; then
+  cache_dir="${op_dir}/cache"
 elif [ "$XDG_CACHE_HOME" != "" ]; then
   cache_dir="${XDG_CACHE_HOME}/1pass"
 else

--- a/1pass
+++ b/1pass
@@ -58,7 +58,7 @@ fi
 
 # test setup:
 if [ ! -d "$op_dir" ] || [ ! -r "${op_dir}/config" ]; then
-    mkdir -p "$cache_dir"
+    mkdir -p "$op_dir"
     cat > "${op_dir}/config" <<CONFIG
 # configuration file for 1pass
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ any running gpg-agent of your GPG secret keys.
 In order to run with minimum user input, **1pass** relies on the Gnu Privacy Guard
 [gpg](https://gnupg.org/) to encrypt all locally stored data. 1Password needs both a *master
 password* and a *secret key* to access your vault. Each of these must be stored in an encrypted
-file (in ~/.1pass or `$XDG_CONFIG_HOME/1pass`) for 1pass to work correctly. 1pass encrypts these
+file (in `$OVERRIDE_1PASS_CONF_DIR` or `$XDG_CONFIG_HOME/1pass`) for 1pass to work correctly. 1pass encrypts these
 and all other files with your own gpg key. This key, as well as your 1Password login email and
 domain must be configured in the ~/.1pass/config file. The domain is the full domain name that you
 use to sign-in when you use the 1Password website, for example `example.1password.com` or
@@ -292,7 +292,7 @@ happen in their own window.
 ## Caching and Sessions
 
 When using **1pass**, all response data from 1Password is encrypted and then cached to
-```~/.1pass/cache```. Sometimes this cache will be out of date -- for example if you have created a
+```${XDG_CACHE_HOME}/1pass"``` (you can override this location with `$OVERRIDE_1PASS_CACHE_DIR`). Sometimes this cache will be out of date -- for example if you have created a
 new password entry via the 1Password application. Passing ```-r``` to **1pass** will force a refresh
 from the online 1Password vault.
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ any running gpg-agent of your GPG secret keys.
 In order to run with minimum user input, **1pass** relies on the Gnu Privacy Guard
 [gpg](https://gnupg.org/) to encrypt all locally stored data. 1Password needs both a *master
 password* and a *secret key* to access your vault. Each of these must be stored in an encrypted
-file (in `$OVERRIDE_1PASS_CONF_DIR` or `$XDG_CONFIG_HOME/1pass`) for 1pass to work correctly. 1pass encrypts these
+file (in ~/.1pass or `$XDG_CONFIG_HOME/1pass`) for 1pass to work correctly. 1pass encrypts these
 and all other files with your own gpg key. This key, as well as your 1Password login email and
 domain must be configured in the ~/.1pass/config file. The domain is the full domain name that you
 use to sign-in when you use the 1Password website, for example `example.1password.com` or
@@ -292,7 +292,7 @@ happen in their own window.
 ## Caching and Sessions
 
 When using **1pass**, all response data from 1Password is encrypted and then cached to
-```${XDG_CACHE_HOME}/1pass"``` (you can override this location with `$OVERRIDE_1PASS_CACHE_DIR`). Sometimes this cache will be out of date -- for example if you have created a
+```~/.1pass/cache```. Sometimes this cache will be out of date -- for example if you have created a
 new password entry via the 1Password application. Passing ```-r``` to **1pass** will force a refresh
 from the online 1Password vault.
 


### PR DESCRIPTION
Hopefully this isn't too controversial, but the xdg base dir specification states that:
```
If $XDG_CONFIG_HOME is either not set or empty, a default equal to $HOME/.config should be used.
```
[ref from specification](https://specifications.freedesktop.org/basedir-spec/latest/ar01s03.html) (similar for cache dir.).

We continue to check whether the old config directory is present first so that if people upgrade, they won't need to change anything, but otherwise, we default to following the specification.